### PR TITLE
Dockerized MCIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM php:5.6.13-apache
+
+# Install extra php modules
+RUN apt-get update
+RUN apt-get install -y php5-xsl php5-mcrypt libmcrypt-dev libxslt1-dev
+RUN docker-php-ext-install mcrypt xsl mysql
+
+# Add source
+COPY . /var/www/html/
+
+# Configure mysql credentials / must match the ones in docker-compose.yml
+RUN sed -i "s/default_mcir_db_password/mcirpass00112233/" sqlol/includes/database.config.php
+RUN sed -i "s/default_mcir_db_password/mcirpass00112233/" cryptomg/includes/db.inc.php
+
+RUN sed -i "s/localhost/mysqldb/" sqlol/includes/database.config.php
+RUN sed -i "s/localhost/mysqldb/" cryptomg/includes/db.inc.php
+
+# Misc
+RUN chmod 666 xssmh/pxss.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+mysqldb:
+  image: mysql
+  environment:
+    - MYSQL_ROOT_PASSWORD=mcirpass00112233
+    - MYSQL_DATABASE=sqlol
+
+mcir:
+  image: andresriancho/mcir:latest
+  ports:
+    - "8090:80"
+  links:
+    - mysqldb
+  environment:
+    - APACHE_RUN_USER=www-data
+    - APACHE_RUN_GROUP=www-data
+    - APACHE_LOG_DIR=/var/log/apache2/
+


### PR DESCRIPTION
This PR is related with https://github.com/SpiderLabs/MCIR/issues/3 (MCIR docker image). Usage:

```
cd MCIR
docker-compose up
```

Then browse to http://127.0.0.1:8090/ and you'll see a running MCIR

TODOs and problems:
 * Some tests might run, but I couldn't find the SQL schema for the `sqlol` database in the repository, so the DB is created (see docker-compose.yml) but it's empty. Could you please point me to the DB schema file?
 * The docker-compose file references my public registry image. You might want to do this:
   * Create your own user in the registry
   * `docker build -t your-user/mcir .`
   * `docker push your-user/mcir`
   * Change the yml file to point to your registry entry