### PR TITLE
SQLol doesn't work with the latest version 8 of MySQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 mysqldb:
-  image: mysql
+  image: mysql:5.7.24
   environment:
     - MYSQL_ROOT_PASSWORD=mcirpass00112233
     - MYSQL_DATABASE=sqlol


### PR DESCRIPTION
SQLol doesn't work with the latest version 8 of MySQL. It's better to be specific and set version number to docker image. The latest worked version of MySQL is 5.7.24.

With version 8.0.13 of MySQL, I got the following error, which is the latest docker image:
```
Warning: mysql_connect(): Server sent charset (255) unknown to the client. Please, report to the developers in /var/www/html/sqlol/includes/adodb/drivers/adodb-mysql.inc.php on line 365
Warning: mysql_connect(): Server sent charset unknown to the client. Please, report to the developers in /var/www/html/sqlol/includes/adodb/drivers/adodb-mysql.inc.php on line 365
Could not connect to database. Did you edit includes/database.config.php?
```

It seems the problem is related that MySQL 8 changed the default charset to utfmb4.
More information about this problem: https://stackoverflow.com/a/43442839

Meanwhile this pull request fix that problem for building up the environment with docker.